### PR TITLE
chore: allow specific token sale in secondary market

### DIFF
--- a/sellable/src/errors.rs
+++ b/sellable/src/errors.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{StdError, Uint64};
+use cosmwasm_std::{StdError, Uint128};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -22,10 +22,22 @@ pub enum ContractError {
     NoListedTokensError,
 
     #[error("Limit of {limit} below lowest offer of {lowest_price}")]
-    LimitBelowLowestOffer { limit: Uint64, lowest_price: Uint64 },
+    LimitBelowLowestOffer {
+        limit: Uint128,
+        lowest_price: Uint128,
+    },
+
+    #[error("Funds of {fund} below seat price of {seat_price}")]
+    InsufficientFundsError { fund: Uint128, seat_price: Uint128 },
 
     #[error("No relevant funds present in transaction")]
     NoFundsPresent,
+
+    #[error("Multiple funds present")]
+    MultipleFundsError,
+
+    #[error("Wrong fund in transaction")]
+    WrongFundError,
 
     #[error("{0}")]
     BaseError(#[from] cw721_base::ContractError),

--- a/sellable/src/execute.rs
+++ b/sellable/src/execute.rs
@@ -269,12 +269,11 @@ where
         // check if enough fee was sent
         match info.funds.as_slice() {
             [fund] => {
-                let token = self
+                self
                     .listed_tokens
                     .load(deps.storage, token_id.as_str())
-                    .map_err(|_| ContractError::NoListedTokensError);
-                match token {
-                    Ok(price) => {
+                    .map_err(|_| ContractError::NoListedTokensError)
+                    .and_then(|price| {
                         if fund.denom.ne(&price.denom) {
                             return Err(ContractError::WrongFundError);
                         } else if fund.amount.ge(&price.amount) {
@@ -321,9 +320,7 @@ where
                                 seat_price: price.amount,
                             });
                         }
-                    }
-                    Err(err) => return Err(err),
-                }
+                    })
             }
             [] => return Err(ContractError::NoFundsPresent),
             _ => return Err(ContractError::MultipleFundsError),

--- a/sellable/src/execute.rs
+++ b/sellable/src/execute.rs
@@ -1,8 +1,8 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, ops::Sub, rc::Rc};
 
 use crate::{errors::ContractError, RSellable, Sellable};
 use cosmwasm_std::{
-    BankMsg, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Order, Response, Uint64,
+    BankMsg, Binary, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Order, Response, Uint128,
 };
 use cw_storage_plus::Map;
 use ownable::Ownable;
@@ -20,7 +20,7 @@ where
     pub fn new(
         tokens_module: Rc<RefCell<Tokens<'a, T, C, E, Q>>>,
         ownable_module: Rc<RefCell<Ownable<'a>>>,
-        listed_tokens: Map<'a, &'a str, Uint64>,
+        listed_tokens: Map<'a, &'a str, Coin>,
     ) -> Self {
         Self {
             tokens: tokens_module,
@@ -34,13 +34,13 @@ where
         deps: &mut DepsMut,
         env: Env,
         info: MessageInfo,
-        listings: schemars::Map<String, Uint64>,
-    ) -> Result<Response, ContractError> {
+        listings: schemars::Map<String, Coin>,
+    ) -> Result<Response<Binary>, ContractError> {
         let ownable = &self.ownable.borrow();
         check_ownable(&deps.as_ref(), &env, &info, ownable)?;
 
         for (token_id, price) in listings {
-            if price > Uint64::new(0) {
+            if price.amount > Uint128::new(0) {
                 if let Ok(Some(_)) = self
                     .tokens
                     .borrow()
@@ -58,7 +58,75 @@ where
         Ok(Response::new().add_attribute("method", "list"))
     }
 
-    pub fn try_buy(&mut self, deps: &mut DepsMut, info: MessageInfo) -> Result<Response, ContractError> {
+    pub fn try_buy_token(
+        &mut self,
+        deps: &mut DepsMut,
+        info: MessageInfo,
+        token_id: String,
+    ) -> Result<Response<Binary>, ContractError> {
+        // check if enough fee was sent
+        if info.funds.len() == 0 {
+            return Err(ContractError::NoFundsPresent);
+        } else if info.funds.len() > 1 {
+            return Err(ContractError::MultipleFundsError);
+        } else {
+            let token = self
+                .listed_tokens
+                .load(deps.storage, token_id.as_str())
+                .map_err(|_| ContractError::NoListedTokensError);
+            match token {
+                Ok(price) => {
+                    if info.funds[0].denom.ne(&price.denom) {
+                        return Err(ContractError::WrongFundError);
+                    } else if info.funds[0].amount.ge(&price.amount) {
+                        let token_metadata = self
+                            .tokens
+                            .borrow()
+                            .contract
+                            .tokens
+                            .load(deps.storage, &token_id)
+                            .map_err(|_| ContractError::NoMetadataPresent)?;
+                        self.tokens
+                            .borrow_mut()
+                            .contract
+                            .tokens
+                            .update::<_, ContractError>(deps.storage, token_id.as_str(), |old| {
+                                let mut token_info = old.unwrap();
+                                token_info.owner = info.sender.clone();
+                                Ok(token_info)
+                            })?;
+                        self.listed_tokens.remove(deps.storage, &token_id);
+
+                        let delta = info.funds[0].amount.sub(price.amount);
+                        let mut messages = vec![BankMsg::Send {
+                            to_address: token_metadata.owner.to_string(),
+                            amount: vec![price.clone()],
+                        }];
+                        if !delta.is_zero() {
+                            messages.push(BankMsg::Send {
+                                to_address: info.sender.to_string(),
+                                amount: vec![Coin::new(delta.u128(), &price.denom)],
+                            })
+                        }
+                        // TODO: Send royalties to minter
+                        return Ok(Response::new().add_messages(messages));
+                    } else {
+                        return Err(ContractError::InsufficientFundsError {
+                            fund: info.funds[0].amount,
+                            seat_price: price.amount,
+                        });
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    pub fn try_buy(
+        &mut self,
+        deps: &mut DepsMut,
+        info: MessageInfo,
+    ) -> Result<Response<Binary>, ContractError> {
         let denom_name: String;
         if let Some(denom) = self.tokens.borrow().name.clone() {
             denom_name = denom;
@@ -75,8 +143,8 @@ where
                 .listed_tokens
                 .range(deps.storage, None, None, Order::Descending)
                 .map(|t| t.unwrap())
-                .collect::<Vec<(String, Uint64)>>();
-            sorted_tokens.sort_unstable_by_key(|t| t.1);
+                .collect::<Vec<(String, Coin)>>();
+            sorted_tokens.sort_unstable_by_key(|t| t.1.amount);
             if sorted_tokens.len() == 0 {
                 return Err(ContractError::NoListedTokensError);
             }
@@ -88,7 +156,7 @@ where
             let lowest = Ok((
                 lowest_listed_token.clone().0,
                 token_info.owner,
-                lowest_listed_token.1,
+                lowest_listed_token.1.amount,
             ));
 
             lowest
@@ -98,7 +166,7 @@ where
                     } else {
                         Err(ContractError::LimitBelowLowestOffer {
                             limit,
-                            lowest_price,
+                            lowest_price: lowest_price,
                         })
                     }
                 })
@@ -115,16 +183,16 @@ where
                     self.listed_tokens
                         .remove(deps.storage, lowest_token_id.as_str());
 
-                    let payment_coin = Coin::new(lowest_price.u64() as u128, &denom_name);
+                    let payment_coin = Coin::new(lowest_price.into(), &denom_name);
                     let delta = limit - lowest_price;
                     let mut messages = vec![BankMsg::Send {
                         to_address: lowest_token_owner.to_string(),
                         amount: vec![payment_coin],
                     }];
-                    if delta.u64() > 0 {
+                    if delta > Uint128::new(0) {
                         messages.push(BankMsg::Send {
                             to_address: info.sender.to_string(),
-                            amount: vec![Coin::new(delta.u64() as u128, &denom_name)],
+                            amount: vec![Coin::new(delta.into(), &denom_name)],
                         })
                     }
 
@@ -148,7 +216,7 @@ where
     pub fn new(
         token_module: Rc<RefCell<Tokens<'a, T, C, E, Q>>>,
         ownable_module: Rc<RefCell<Ownable<'a>>>,
-        listed_tokens: Map<'a, &'a str, Uint64>,
+        listed_tokens: Map<'a, &'a str, Coin>,
         redeemable_module: Rc<RefCell<Redeemable<'a>>>,
     ) -> Self {
         Self {
@@ -164,14 +232,14 @@ where
         deps: &mut DepsMut,
         env: Env,
         info: MessageInfo,
-        listings: schemars::Map<String, Uint64>,
-    ) -> Result<Response, ContractError> {
+        listings: schemars::Map<String, Coin>,
+    ) -> Result<Response<Binary>, ContractError> {
         let ownable = &self.ownable.borrow();
         let redeemable = &self.redeemable.borrow();
 
         check_ownable(&deps.as_ref(), &env, &info, ownable)?;
         for (token_id, price) in listings {
-            if price > Uint64::new(0) {
+            if price.amount > Uint128::new(0) {
                 if let Some(_) = self
                     .tokens
                     .borrow()
@@ -191,12 +259,79 @@ where
         Ok(Response::new().add_attribute("method", "list"))
     }
 
+    pub fn try_buy_token(
+        &mut self,
+        deps: &mut DepsMut,
+        env: &Env,
+        info: MessageInfo,
+        token_id: String,
+    ) -> Result<Response<Binary>, ContractError> {
+        // check if enough fee was sent
+        if info.funds.len() == 0 {
+            return Err(ContractError::NoFundsPresent);
+        } else if info.funds.len() > 1 {
+            return Err(ContractError::MultipleFundsError);
+        } else {
+            let token = self
+                .listed_tokens
+                .load(deps.storage, token_id.as_str())
+                .map_err(|_| ContractError::NoListedTokensError);
+            match token {
+                Ok(price) => {
+                    if info.funds[0].denom.ne(&price.denom) {
+                        return Err(ContractError::WrongFundError);
+                    } else if info.funds[0].amount.ge(&price.amount) {
+                        let redeemable = &self.redeemable.borrow();
+                        check_redeemable(&deps.as_ref(), env, &info, &token_id, redeemable)?;
+                        let token_metadata = self
+                            .tokens
+                            .borrow()
+                            .contract
+                            .tokens
+                            .load(deps.storage, &token_id)
+                            .map_err(|_| ContractError::NoMetadataPresent)?;
+                        self.tokens
+                            .borrow_mut()
+                            .contract
+                            .tokens
+                            .update::<_, ContractError>(deps.storage, token_id.as_str(), |old| {
+                                let mut token_info = old.unwrap();
+                                token_info.owner = info.sender.clone();
+                                Ok(token_info)
+                            })?;
+                        self.listed_tokens.remove(deps.storage, &token_id);
+
+                        let delta = info.funds[0].amount.sub(price.amount);
+                        let mut messages = vec![BankMsg::Send {
+                            to_address: token_metadata.owner.to_string(),
+                            amount: vec![price.clone()],
+                        }];
+                        if !delta.is_zero() {
+                            messages.push(BankMsg::Send {
+                                to_address: info.sender.to_string(),
+                                amount: vec![Coin::new(delta.u128(), &price.denom)],
+                            })
+                        }
+
+                        return Ok(Response::new().add_messages(messages));
+                    } else {
+                        return Err(ContractError::InsufficientFundsError {
+                            fund: info.funds[0].amount,
+                            seat_price: price.amount,
+                        });
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
     pub fn try_buy(
         &mut self,
         deps: DepsMut,
         env: &Env,
         info: MessageInfo,
-    ) -> Result<Response, ContractError> {
+    ) -> Result<Response<Binary>, ContractError> {
         let denom_name: String;
         if let Some(denom) = self.tokens.borrow().name.clone() {
             denom_name = denom;
@@ -209,14 +344,14 @@ where
         let maybe_coin = info.funds.iter().find(|&coin| coin.denom.eq(&denom_name));
 
         if let Some(coin) = maybe_coin {
-            let limit = (coin.amount.u128() as u64).into();
+            let limit = coin.amount;
 
             let mut sorted_tokens = self
                 .listed_tokens
                 .range(deps.storage, None, None, Order::Descending)
                 .map(|t| t.unwrap())
-                .collect::<Vec<(String, Uint64)>>();
-            sorted_tokens.sort_unstable_by_key(|t| t.1);
+                .collect::<Vec<(String, Coin)>>();
+            sorted_tokens.sort_unstable_by_key(|t| t.1.amount);
             if sorted_tokens.len() == 0 {
                 return Err(ContractError::NoListedTokensError);
             }
@@ -236,7 +371,7 @@ where
             let lowest = Ok((
                 lowest_listed_token.clone().0,
                 token_info.owner,
-                lowest_listed_token.1,
+                lowest_listed_token.1.amount,
             ));
 
             lowest
@@ -246,7 +381,7 @@ where
                     } else {
                         Err(ContractError::LimitBelowLowestOffer {
                             limit,
-                            lowest_price,
+                            lowest_price: lowest_price,
                         })
                     }
                 })
@@ -263,16 +398,16 @@ where
                     self.listed_tokens
                         .remove(deps.storage, lowest_token_id.as_str());
 
-                    let payment_coin = Coin::new(lowest_price.u64() as u128, &denom_name);
+                    let payment_coin = Coin::new(lowest_price.into(), &denom_name);
                     let delta = limit - lowest_price;
                     let mut messages = vec![BankMsg::Send {
                         to_address: lowest_token_owner.to_string(),
                         amount: vec![payment_coin],
                     }];
-                    if delta.u64() > 0 {
+                    if delta > Uint128::new(0) {
                         messages.push(BankMsg::Send {
                             to_address: info.sender.to_string(),
-                            amount: vec![Coin::new(delta.u64() as u128, &denom_name)],
+                            amount: vec![Coin::new(delta.into(), &denom_name)],
                         })
                     }
 

--- a/sellable/src/execute.rs
+++ b/sellable/src/execute.rs
@@ -1,8 +1,9 @@
 use std::{cell::RefCell, ops::Sub, rc::Rc};
 
 use crate::{errors::ContractError, RSellable, Sellable};
+use burnt_glue::response::Response;
 use cosmwasm_std::{
-    BankMsg, Binary, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Order, Response, Uint128,
+    BankMsg, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Order, Uint128,
 };
 use cw_storage_plus::Map;
 use ownable::Ownable;
@@ -35,7 +36,7 @@ where
         env: Env,
         info: MessageInfo,
         listings: schemars::Map<String, Coin>,
-    ) -> Result<Response<Binary>, ContractError> {
+    ) -> Result<Response, ContractError> {
         let ownable = &self.ownable.borrow();
         check_ownable(&deps.as_ref(), &env, &info, ownable)?;
 
@@ -63,7 +64,7 @@ where
         deps: &mut DepsMut,
         info: MessageInfo,
         token_id: String,
-    ) -> Result<Response<Binary>, ContractError> {
+    ) -> Result<Response, ContractError> {
         // check if enough fee was sent
         if info.funds.len() == 0 {
             return Err(ContractError::NoFundsPresent);
@@ -126,7 +127,7 @@ where
         &mut self,
         deps: &mut DepsMut,
         info: MessageInfo,
-    ) -> Result<Response<Binary>, ContractError> {
+    ) -> Result<Response, ContractError> {
         let denom_name: String;
         if let Some(denom) = self.tokens.borrow().name.clone() {
             denom_name = denom;
@@ -233,7 +234,7 @@ where
         env: Env,
         info: MessageInfo,
         listings: schemars::Map<String, Coin>,
-    ) -> Result<Response<Binary>, ContractError> {
+    ) -> Result<Response, ContractError> {
         let ownable = &self.ownable.borrow();
         let redeemable = &self.redeemable.borrow();
 
@@ -265,7 +266,7 @@ where
         env: &Env,
         info: MessageInfo,
         token_id: String,
-    ) -> Result<Response<Binary>, ContractError> {
+    ) -> Result<Response, ContractError> {
         // check if enough fee was sent
         if info.funds.len() == 0 {
             return Err(ContractError::NoFundsPresent);
@@ -331,7 +332,7 @@ where
         deps: DepsMut,
         env: &Env,
         info: MessageInfo,
-    ) -> Result<Response<Binary>, ContractError> {
+    ) -> Result<Response, ContractError> {
         let denom_name: String;
         if let Some(denom) = self.tokens.borrow().name.clone() {
             denom_name = denom;

--- a/sellable/src/execute.rs
+++ b/sellable/src/execute.rs
@@ -66,12 +66,11 @@ where
         // check if enough fee was sent
         match info.funds.as_slice() {
             [fund] => {
-                let token = self
+                self
                     .listed_tokens
                     .load(deps.storage, token_id.as_str())
-                    .map_err(|_| ContractError::NoListedTokensError);
-                match token {
-                    Ok(price) => {
+                    .map_err(|_| ContractError::NoListedTokensError)
+                    .and_then(|price| {
                         if fund.denom.ne(&price.denom) {
                             return Err(ContractError::WrongFundError);
                         } else if fund.amount.ge(&price.amount) {
@@ -116,9 +115,7 @@ where
                                 seat_price: price.amount,
                             });
                         }
-                    }
-                    Err(err) => return Err(err),
-                }
+                    })
             }
             [] => return Err(ContractError::NoFundsPresent),
             _ => return Err(ContractError::MultipleFundsError),

--- a/sellable/src/execute.rs
+++ b/sellable/src/execute.rs
@@ -2,9 +2,7 @@ use std::{cell::RefCell, ops::Sub, rc::Rc};
 
 use crate::{errors::ContractError, RSellable, Sellable};
 use burnt_glue::response::Response;
-use cosmwasm_std::{
-    BankMsg, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Order, Uint128,
-};
+use cosmwasm_std::{BankMsg, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Order, Uint128};
 use cw_storage_plus::Map;
 use ownable::Ownable;
 use redeemable::Redeemable;
@@ -66,60 +64,64 @@ where
         token_id: String,
     ) -> Result<Response, ContractError> {
         // check if enough fee was sent
-        if info.funds.len() == 0 {
-            return Err(ContractError::NoFundsPresent);
-        } else if info.funds.len() > 1 {
-            return Err(ContractError::MultipleFundsError);
-        } else {
-            let token = self
-                .listed_tokens
-                .load(deps.storage, token_id.as_str())
-                .map_err(|_| ContractError::NoListedTokensError);
-            match token {
-                Ok(price) => {
-                    if info.funds[0].denom.ne(&price.denom) {
-                        return Err(ContractError::WrongFundError);
-                    } else if info.funds[0].amount.ge(&price.amount) {
-                        let token_metadata = self
-                            .tokens
-                            .borrow()
-                            .contract
-                            .tokens
-                            .load(deps.storage, &token_id)
-                            .map_err(|_| ContractError::NoMetadataPresent)?;
-                        self.tokens
-                            .borrow_mut()
-                            .contract
-                            .tokens
-                            .update::<_, ContractError>(deps.storage, token_id.as_str(), |old| {
-                                let mut token_info = old.unwrap();
-                                token_info.owner = info.sender.clone();
-                                Ok(token_info)
-                            })?;
-                        self.listed_tokens.remove(deps.storage, &token_id);
+        match info.funds.as_slice() {
+            [fund] => {
+                let token = self
+                    .listed_tokens
+                    .load(deps.storage, token_id.as_str())
+                    .map_err(|_| ContractError::NoListedTokensError);
+                match token {
+                    Ok(price) => {
+                        if fund.denom.ne(&price.denom) {
+                            return Err(ContractError::WrongFundError);
+                        } else if fund.amount.ge(&price.amount) {
+                            let token_metadata = self
+                                .tokens
+                                .borrow()
+                                .contract
+                                .tokens
+                                .load(deps.storage, &token_id)
+                                .map_err(|_| ContractError::NoMetadataPresent)?;
+                            self.tokens
+                                .borrow_mut()
+                                .contract
+                                .tokens
+                                .update::<_, ContractError>(
+                                    deps.storage,
+                                    token_id.as_str(),
+                                    |old| {
+                                        let mut token_info = old.unwrap();
+                                        token_info.owner = info.sender.clone();
+                                        Ok(token_info)
+                                    },
+                                )?;
+                            self.listed_tokens.remove(deps.storage, &token_id);
 
-                        let delta = info.funds[0].amount.sub(price.amount);
-                        let mut messages = vec![BankMsg::Send {
-                            to_address: token_metadata.owner.to_string(),
-                            amount: vec![price.clone()],
-                        }];
-                        if !delta.is_zero() {
-                            messages.push(BankMsg::Send {
-                                to_address: info.sender.to_string(),
-                                amount: vec![Coin::new(delta.u128(), &price.denom)],
-                            })
+                            let delta = fund.amount.sub(price.amount);
+                            let mut messages = vec![BankMsg::Send {
+                                to_address: token_metadata.owner.to_string(),
+                                amount: vec![price.clone()],
+                            }];
+                            if !delta.is_zero() {
+                                messages.push(BankMsg::Send {
+                                    to_address: info.sender.to_string(),
+                                    amount: vec![Coin::new(delta.u128(), &price.denom)],
+                                })
+                            }
+                            // TODO: Send royalties to minter
+                            return Ok(Response::new().add_messages(messages));
+                        } else {
+                            return Err(ContractError::InsufficientFundsError {
+                                fund: fund.amount,
+                                seat_price: price.amount,
+                            });
                         }
-                        // TODO: Send royalties to minter
-                        return Ok(Response::new().add_messages(messages));
-                    } else {
-                        return Err(ContractError::InsufficientFundsError {
-                            fund: info.funds[0].amount,
-                            seat_price: price.amount,
-                        });
                     }
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
             }
+            [] => return Err(ContractError::NoFundsPresent),
+            _ => return Err(ContractError::MultipleFundsError),
         }
     }
 
@@ -268,62 +270,66 @@ where
         token_id: String,
     ) -> Result<Response, ContractError> {
         // check if enough fee was sent
-        if info.funds.len() == 0 {
-            return Err(ContractError::NoFundsPresent);
-        } else if info.funds.len() > 1 {
-            return Err(ContractError::MultipleFundsError);
-        } else {
-            let token = self
-                .listed_tokens
-                .load(deps.storage, token_id.as_str())
-                .map_err(|_| ContractError::NoListedTokensError);
-            match token {
-                Ok(price) => {
-                    if info.funds[0].denom.ne(&price.denom) {
-                        return Err(ContractError::WrongFundError);
-                    } else if info.funds[0].amount.ge(&price.amount) {
-                        let redeemable = &self.redeemable.borrow();
-                        check_redeemable(&deps.as_ref(), env, &info, &token_id, redeemable)?;
-                        let token_metadata = self
-                            .tokens
-                            .borrow()
-                            .contract
-                            .tokens
-                            .load(deps.storage, &token_id)
-                            .map_err(|_| ContractError::NoMetadataPresent)?;
-                        self.tokens
-                            .borrow_mut()
-                            .contract
-                            .tokens
-                            .update::<_, ContractError>(deps.storage, token_id.as_str(), |old| {
-                                let mut token_info = old.unwrap();
-                                token_info.owner = info.sender.clone();
-                                Ok(token_info)
-                            })?;
-                        self.listed_tokens.remove(deps.storage, &token_id);
+        match info.funds.as_slice() {
+            [fund] => {
+                let token = self
+                    .listed_tokens
+                    .load(deps.storage, token_id.as_str())
+                    .map_err(|_| ContractError::NoListedTokensError);
+                match token {
+                    Ok(price) => {
+                        if fund.denom.ne(&price.denom) {
+                            return Err(ContractError::WrongFundError);
+                        } else if fund.amount.ge(&price.amount) {
+                            let redeemable = &self.redeemable.borrow();
+                            check_redeemable(&deps.as_ref(), env, &info, &token_id, redeemable)?;
+                            let token_metadata = self
+                                .tokens
+                                .borrow()
+                                .contract
+                                .tokens
+                                .load(deps.storage, &token_id)
+                                .map_err(|_| ContractError::NoMetadataPresent)?;
+                            self.tokens
+                                .borrow_mut()
+                                .contract
+                                .tokens
+                                .update::<_, ContractError>(
+                                    deps.storage,
+                                    token_id.as_str(),
+                                    |old| {
+                                        let mut token_info = old.unwrap();
+                                        token_info.owner = info.sender.clone();
+                                        Ok(token_info)
+                                    },
+                                )?;
+                            self.listed_tokens.remove(deps.storage, &token_id);
 
-                        let delta = info.funds[0].amount.sub(price.amount);
-                        let mut messages = vec![BankMsg::Send {
-                            to_address: token_metadata.owner.to_string(),
-                            amount: vec![price.clone()],
-                        }];
-                        if !delta.is_zero() {
-                            messages.push(BankMsg::Send {
-                                to_address: info.sender.to_string(),
-                                amount: vec![Coin::new(delta.u128(), &price.denom)],
-                            })
+                            let delta = fund.amount.sub(price.amount);
+                            let mut messages = vec![BankMsg::Send {
+                                to_address: token_metadata.owner.to_string(),
+                                amount: vec![price.clone()],
+                            }];
+                            if !delta.is_zero() {
+                                messages.push(BankMsg::Send {
+                                    to_address: info.sender.to_string(),
+                                    amount: vec![Coin::new(delta.u128(), &price.denom)],
+                                })
+                            }
+
+                            return Ok(Response::new().add_messages(messages));
+                        } else {
+                            return Err(ContractError::InsufficientFundsError {
+                                fund: fund.amount,
+                                seat_price: price.amount,
+                            });
                         }
-
-                        return Ok(Response::new().add_messages(messages));
-                    } else {
-                        return Err(ContractError::InsufficientFundsError {
-                            fund: info.funds[0].amount,
-                            seat_price: price.amount,
-                        });
                     }
+                    Err(err) => return Err(err),
                 }
-                Err(err) => return Err(err),
             }
+            [] => return Err(ContractError::NoFundsPresent),
+            _ => return Err(ContractError::MultipleFundsError),
         }
     }
 

--- a/sellable/src/lib.rs
+++ b/sellable/src/lib.rs
@@ -10,7 +10,7 @@ use state::LISTED_TOKENS;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use cosmwasm_std::{CustomMsg, Deps, DepsMut, Env, MessageInfo, Uint64};
+use cosmwasm_std::{Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo};
 use errors::ContractError;
 use msg::{ExecuteMsg, InstantiateMsg, QueryMsg, QueryResp};
 use ownable::Ownable;
@@ -31,7 +31,7 @@ where
 {
     pub tokens: Rc<RefCell<Tokens<'a, T, C, E, Q>>>,
     pub ownable: Rc<RefCell<Ownable<'a>>>,
-    pub listed_tokens: Map<'a, &'a str, Uint64>,
+    pub listed_tokens: Map<'a, &'a str, Coin>,
 }
 
 pub struct RSellable<'a, T, C, E, Q>
@@ -43,7 +43,7 @@ where
 {
     pub tokens: Rc<RefCell<Tokens<'a, T, C, E, Q>>>,
     pub ownable: Rc<RefCell<Ownable<'a>>>,
-    pub listed_tokens: Map<'a, &'a str, Uint64>,
+    pub listed_tokens: Map<'a, &'a str, Coin>,
     pub redeemable: Rc<RefCell<Redeemable<'a>>>,
 }
 
@@ -113,15 +113,15 @@ where
         info: MessageInfo,
         msg: ExecuteMsg,
     ) -> Result<Response, Self::Error> {
-        match msg {
-            ExecuteMsg::Buy {} => {
-                self.try_buy(deps, info)?;
-            }
-            ExecuteMsg::List { listings } => {
-                self.try_list(deps, env, info, listings)?;
-            }
-        }
-        Ok(Response::new())
+        let res = match msg {
+            ExecuteMsg::Buy {} => self.try_buy(deps, info),
+            ExecuteMsg::List { listings } => self.try_list(deps, env, info, listings),
+            ExecuteMsg::BuyToken { token_id } => self.try_buy_token(deps, info, token_id),
+        };
+        res.map(|resp| burnt_glue::response::Response {
+            response: resp,
+            data: serde_json::Value::Null,
+        })
     }
 
     fn query(&self, deps: &Deps, _env: Env, msg: QueryMsg) -> Result<Self::QueryResp, Self::Error> {
@@ -164,15 +164,15 @@ where
         info: MessageInfo,
         msg: ExecuteMsg,
     ) -> Result<Response, Self::Error> {
-        match msg {
-            ExecuteMsg::Buy {} => {
-                self.try_buy(deps.branch(), &env, info)?;
-            }
-            ExecuteMsg::List { listings } => {
-                self.try_list(deps, env, info, listings)?;
-            }
-        }
-        Ok(Response::new())
+        let res = match msg {
+            ExecuteMsg::Buy {} => self.try_buy(deps.branch(), &env, info),
+            ExecuteMsg::List { listings } => self.try_list(deps, env, info, listings),
+            ExecuteMsg::BuyToken { token_id } => self.try_buy_token(deps, &env, info, token_id),
+        };
+        res.map(|resp| burnt_glue::response::Response {
+            response: resp,
+            data: serde_json::Value::Null,
+        })
     }
 
     fn query(&self, deps: &Deps, _env: Env, msg: QueryMsg) -> Result<Self::QueryResp, Self::Error> {

--- a/sellable/src/lib.rs
+++ b/sellable/src/lib.rs
@@ -113,15 +113,11 @@ where
         info: MessageInfo,
         msg: ExecuteMsg,
     ) -> Result<Response, Self::Error> {
-        let res = match msg {
+        return match msg {
             ExecuteMsg::Buy {} => self.try_buy(deps, info),
             ExecuteMsg::List { listings } => self.try_list(deps, env, info, listings),
             ExecuteMsg::BuyToken { token_id } => self.try_buy_token(deps, info, token_id),
         };
-        res.map(|resp| burnt_glue::response::Response {
-            response: resp,
-            data: serde_json::Value::Null,
-        })
     }
 
     fn query(&self, deps: &Deps, _env: Env, msg: QueryMsg) -> Result<Self::QueryResp, Self::Error> {
@@ -164,15 +160,11 @@ where
         info: MessageInfo,
         msg: ExecuteMsg,
     ) -> Result<Response, Self::Error> {
-        let res = match msg {
+        return match msg {
             ExecuteMsg::Buy {} => self.try_buy(deps.branch(), &env, info),
             ExecuteMsg::List { listings } => self.try_list(deps, env, info, listings),
             ExecuteMsg::BuyToken { token_id } => self.try_buy_token(deps, &env, info, token_id),
         };
-        res.map(|resp| burnt_glue::response::Response {
-            response: resp,
-            data: serde_json::Value::Null,
-        })
     }
 
     fn query(&self, deps: &Deps, _env: Env, msg: QueryMsg) -> Result<Self::QueryResp, Self::Error> {

--- a/sellable/src/msg.rs
+++ b/sellable/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Uint64;
+use cosmwasm_std::Coin;
 use cw721_base::state::TokenInfo;
 use schemars::{JsonSchema, Map};
 use serde::{Deserialize, Serialize};
@@ -6,13 +6,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InstantiateMsg {
-    pub tokens: Map<String, Uint64>,
+    pub tokens: Map<String, Coin>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryResp<T> {
-    ListedTokens(Vec<(String, Uint64, TokenInfo<T>)>),
+    ListedTokens(Vec<(String, Coin, TokenInfo<T>)>),
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -21,11 +21,17 @@ pub enum ExecuteMsg {
     /// Sellable specific functions
 
     /// Lists the NFT at the given price
-    List { listings: Map<String, Uint64> },
+    List {
+        listings: Map<String, Coin>,
+    },
 
     /// Purchases the cheapest listed NFT. The value passed along with the
     /// transaction will act as the upper bound for the purchase price.
     Buy {},
+
+    BuyToken {
+        token_id: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/sellable/src/query.rs
+++ b/sellable/src/query.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use cosmwasm_std::{CustomMsg, Deps, Order, StdResult, Uint64};
+use cosmwasm_std::{Coin, CustomMsg, Deps, Order, StdResult};
 use cw721_base::state::TokenInfo;
 use cw_storage_plus::Bound;
 use schemars::JsonSchema;
@@ -39,7 +39,7 @@ where
                 let token_info = contract.tokens.load(deps.storage, res.0.as_str()).unwrap();
                 return (res.0, res.1, token_info);
             })
-            .collect::<Vec<(String, Uint64, TokenInfo<T>)>>();
+            .collect::<Vec<(String, Coin, TokenInfo<T>)>>();
 
         Ok(ListedTokensResponse {
             tokens: listed_tokens_sorted,
@@ -75,7 +75,7 @@ where
                 let token_info = contract.tokens.load(deps.storage, res.0.as_str()).unwrap();
                 return (res.0, res.1, token_info);
             })
-            .collect::<Vec<(String, Uint64, TokenInfo<T>)>>();
+            .collect::<Vec<(String, Coin, TokenInfo<T>)>>();
 
         Ok(ListedTokensResponse {
             tokens: listed_tokens_sorted,
@@ -88,5 +88,5 @@ pub struct ListedTokensResponse<T> {
     /// Contains all token_ids in lexicographical ordering
     /// If there are more than `limit`, use `start_from` in future queries
     /// to achieve pagination.
-    pub tokens: Vec<(String, Uint64, TokenInfo<T>)>,
+    pub tokens: Vec<(String, Coin, TokenInfo<T>)>,
 }

--- a/sellable/src/state.rs
+++ b/sellable/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Uint64;
+use cosmwasm_std::Coin;
 use cw_storage_plus::Map;
 
-pub const LISTED_TOKENS: Map<&str, Uint64> = Map::new("listed_tokens");
+pub const LISTED_TOKENS: Map<&str, Coin> = Map::new("listed_tokens");

--- a/sellable/src/test.rs
+++ b/sellable/src/test.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use cosmwasm_std::{
         testing::{mock_dependencies, mock_env, mock_info},
-        Addr, Empty, Uint64,
+        Addr, BankMsg, Coin, CosmosMsg, DepsMut, Empty, Env, MessageInfo, Uint128,
     };
     use cw721_base::{msg::InstantiateMsg as cw721_baseInstantiateMsg, MintMsg};
     use cw_storage_plus::Map;
@@ -14,14 +14,14 @@ mod tests {
     use crate::{errors::ContractError, Sellable};
 
     const CREATOR: &str = "cosmos188rjfzzrdxlus60zgnrvs4rg0l73hct3azv93z";
+    const BUYER: &str = "burnt1e2fuwe3uhq8zd9nkkk876nawrwdulgv47mkgww";
 
-    #[test]
-    fn sellable_token_list() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let info = mock_info(CREATOR, &[]);
-
-        let mut sellable = Sellable::<Empty, Empty, Empty, Empty>::new(
+    fn setup_sellable_module(
+        deps: &mut DepsMut,
+        env: &Env,
+        info: &MessageInfo,
+    ) -> Sellable<'static, Empty, Empty, Empty, Empty> {
+        let sellable = Sellable::<Empty, Empty, Empty, Empty>::new(
             Rc::new(RefCell::new(Tokens::default())),
             Rc::new(RefCell::new(Ownable::default())),
             Map::new("listed_tokens"),
@@ -31,7 +31,7 @@ mod tests {
             .ownable
             .borrow_mut()
             .owner
-            .save(&mut deps.storage, &Addr::unchecked(CREATOR))
+            .save(deps.storage, &Addr::unchecked(CREATOR))
             .unwrap();
         // Instantiate the token contract
         sellable
@@ -39,7 +39,7 @@ mod tests {
             .borrow()
             .contract
             .instantiate(
-                deps.as_mut(),
+                deps.branch(),
                 env.clone(),
                 info.clone(),
                 cw721_baseInstantiateMsg {
@@ -49,6 +49,15 @@ mod tests {
                 },
             )
             .unwrap();
+        sellable
+    }
+    #[test]
+    fn sellable_token_list() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info(CREATOR, &[]);
+
+        let mut sellable = setup_sellable_module(&mut deps.as_mut(), &env, &info);
         // Mint a token
         sellable
             .tokens
@@ -68,13 +77,25 @@ mod tests {
             .unwrap();
 
         // List a token
-        let listings = schemars::Map::from([("1".to_string(), Uint64::new(10))]);
+        let listings = schemars::Map::from([(
+            "1".to_string(),
+            Coin {
+                amount: Uint128::new(10),
+                denom: "uturnt".to_string(),
+            },
+        )]);
         sellable
             .try_list(&mut deps.as_mut(), env.clone(), info.clone(), listings)
             .unwrap();
 
         // List a non-minted token
-        let non_minted_listings = schemars::Map::from([("hello".to_string(), Uint64::new(10))]);
+        let non_minted_listings = schemars::Map::from([(
+            "hello".to_string(),
+            Coin {
+                amount: Uint128::new(10),
+                denom: "uturnt".to_string(),
+            },
+        )]);
         let list_result = sellable.try_list(
             &mut deps.as_mut(),
             env.clone(),
@@ -91,5 +112,134 @@ mod tests {
 
         let result = sellable.listed_tokens(&deps.as_ref(), None, None).unwrap();
         assert_eq!(result.tokens.len(), 1);
+    }
+
+    #[test]
+    fn test_buy_listed_tokens() {
+        // List a token
+        // Send a request to buy a token with insufficient funds
+        // Send a request to buy with enough fund but wrong fund denom
+        // Send a request to buy with enough funds and denom
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let info = mock_info(CREATOR, &[]);
+
+        let mut sellable = setup_sellable_module(&mut deps.as_mut(), &env, &info);
+        assert_eq!(
+            sellable
+                .tokens
+                .borrow()
+                .contract
+                .token_count(&deps.storage)
+                .unwrap(),
+            0
+        );
+
+        // Mint a token
+        sellable
+            .tokens
+            .borrow_mut()
+            .contract
+            .mint(
+                deps.as_mut(),
+                env.clone(),
+                info.clone(),
+                MintMsg::<Empty> {
+                    token_id: "1".to_string(),
+                    owner: CREATOR.to_string(),
+                    token_uri: Some("uri".to_string()),
+                    extension: Empty {},
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            sellable
+                .tokens
+                .borrow()
+                .contract
+                .token_count(&deps.storage)
+                .unwrap(),
+            1
+        );
+
+        // List newly minted token
+        let listings = schemars::Map::from([(
+            "1".to_string(),
+            Coin {
+                amount: Uint128::new(10),
+                denom: "uturnt".to_string(),
+            },
+        )]);
+        sellable
+            .try_list(&mut deps.as_mut(), env.clone(), info.clone(), listings)
+            .unwrap();
+        let result = sellable.listed_tokens(&deps.as_ref(), None, None).unwrap();
+        assert_eq!(result.tokens.len(), 1);
+
+        // Buy token with no funds
+        sellable
+            .try_buy_token(&mut deps.as_mut(), info, "1".to_string())
+            .expect_err("Expect error");
+
+        // Buy token with insufficient funds
+        let i_funds = mock_info(
+            BUYER,
+            &[Coin {
+                amount: Uint128::new(5),
+                denom: "uturnt".to_string(),
+            }],
+        );
+        sellable
+            .try_buy_token(&mut deps.as_mut(), i_funds, "1".to_string())
+            .expect_err("Expect error");
+
+        // Buy token with sufficient funds and wrong denom
+        let i_funds = mock_info(
+            BUYER,
+            &[Coin {
+                amount: Uint128::new(5),
+                denom: "turnt".to_string(),
+            }],
+        );
+        sellable
+            .try_buy_token(&mut deps.as_mut(), i_funds, "1".to_string())
+            .expect_err("Expect error");
+
+        // Buy token with sufficient funds and enough denom
+        let new_funds = mock_info(
+            BUYER,
+            &[Coin {
+                amount: Uint128::new(12),
+                denom: "uturnt".to_string(),
+            }],
+        );
+        let buy_resp = sellable
+            .try_buy_token(&mut deps.as_mut(), new_funds, "1".to_string())
+            .expect("purchased ticket");
+
+        let result = sellable.listed_tokens(&deps.as_ref(), None, None).unwrap();
+        assert_eq!(result.tokens.len(), 0);
+
+        assert_eq!(buy_resp.messages.len(), 2);
+        assert_eq!(
+            buy_resp.messages[0].msg,
+            CosmosMsg::Bank(BankMsg::Send {
+                to_address: CREATOR.to_string(),
+                amount: vec![Coin {
+                    amount: Uint128::new(10),
+                    denom: "uturnt".to_string()
+                }],
+            })
+        );
+        assert_eq!(
+            buy_resp.messages[1].msg,
+            CosmosMsg::Bank(BankMsg::Send {
+                to_address: BUYER.to_string(),
+                amount: vec![Coin {
+                    amount: Uint128::new(2),
+                    denom: "uturnt".to_string()
+                }],
+            })
+        );
     }
 }

--- a/sellable/src/test.rs
+++ b/sellable/src/test.rs
@@ -220,9 +220,9 @@ mod tests {
         let result = sellable.listed_tokens(&deps.as_ref(), None, None).unwrap();
         assert_eq!(result.tokens.len(), 0);
 
-        assert_eq!(buy_resp.messages.len(), 2);
+        assert_eq!(buy_resp.response.messages.len(), 2);
         assert_eq!(
-            buy_resp.messages[0].msg,
+            buy_resp.response.messages[0].msg,
             CosmosMsg::Bank(BankMsg::Send {
                 to_address: CREATOR.to_string(),
                 amount: vec![Coin {
@@ -232,7 +232,7 @@ mod tests {
             })
         );
         assert_eq!(
-            buy_resp.messages[1].msg,
+            buy_resp.response.messages[1].msg,
             CosmosMsg::Bank(BankMsg::Send {
                 to_address: BUYER.to_string(),
                 amount: vec![Coin {


### PR DESCRIPTION
This PR adds in functionality matching latest secondary market specs

Major change from previous purchase logic is being able to by a specific token as to the lowest listed token. 